### PR TITLE
be robust about column orders in importance_frame

### DIFF
--- a/R/measure_importance.R
+++ b/R/measure_importance.R
@@ -186,7 +186,7 @@ important_variables <- function(importance_frame, k = 15, measures = names(impor
                            frankv(importance_frame$mean_min_depth, ties.method = "dense"),
                          p_value =
                            frankv(importance_frame$p_value, ties.method = "dense"),
-                         apply(importance_frame[, -c(1, 2, 8)], 2,
+                         apply(importance_frame[, !colnames(importance_frame) %in% c("variable", "mean_min_depth", "p_value")], 2,
                                function(x) frankv(x, order = -1, ties.method = "dense")))
   rankings$index <- rowSums(rankings[, measures])
   vars <- as.character(rankings[order(rankings$index), "variable"])[1:min(k, nrow(rankings))]


### PR DESCRIPTION
fixes MI2DataLab/randomForestExplainer#3

(the example in #3 lacks initiation of the variable size_measure, but the real problem is the importance_frame in the example has slightly different order in the column names and important_variables makes strong assumption about the ordering of column names)