### PR TITLE
Exponentially faster tree depth

### DIFF
--- a/R/min_depth_distribution.R
+++ b/R/min_depth_distribution.R
@@ -27,14 +27,14 @@ calculate_tree_depth_ranger <- function(frame){
 # Node indices are assumed to have values in 1:nrow(childs)
 calculate_tree_depth_ <- function(childs) {
   n <- nrow(childs)
-  node_id <- seq_len(n)
   depth <- rep(NA, times = n)
   j <- depth[1L] <- 0
-  ix <- 1
+  ix <- 1L  # current nodes, initialized with root node index
 
   # j loops over tree depth
   while(anyNA(depth) || j >= n) {
-    ix <- c(childs[ix, ])
+    ix <- as.integer(childs[ix, ])
+    ix <- ix[!is.na(ix) & ix >= 1L]  # leave nodes do not have childs
     j <- j + 1
     depth[ix] <- j
   }

--- a/R/min_depth_distribution.R
+++ b/R/min_depth_distribution.R
@@ -5,7 +5,7 @@ calculate_tree_depth <- function(frame){
           It should be a product of the function getTree(..., labelVar = T).")
   }
   frame[["depth"]] <- calculate_tree_depth_(
-    as.matrix(frame[, c("left daughter", "right daughter")])
+    frame[, c("left daughter", "right daughter")]
   )
   return(frame)
 }
@@ -18,14 +18,15 @@ calculate_tree_depth_ranger <- function(frame){
   }
   # Child nodes are zero based, so we increase them by 1
   frame[["depth"]] <- calculate_tree_depth_(
-    as.matrix(frame[, c("leftChild", "rightChild")]) + 1
+    frame[, c("leftChild", "rightChild")] + 1
   )
   return(frame)
 }
 
 # Internal function used to determine the depth of each node.
-# The input is a matrix with left and right child nodes in 1:nrow(childs).
+# The input is a data.frame with left and right child nodes in 1:nrow(childs).
 calculate_tree_depth_ <- function(childs) {
+  childs <- as.matrix(childs)
   n <- nrow(childs)
   depth <- rep(NA, times = n)
   j <- depth[1L] <- 0

--- a/R/min_depth_distribution.R
+++ b/R/min_depth_distribution.R
@@ -4,11 +4,8 @@ calculate_tree_depth <- function(frame){
     stop("The data frame has to contain columns called 'right daughter' and 'left daughter'!
           It should be a product of the function getTree(..., labelVar = T).")
   }
-  # Both child values of leaf nodes are 0, i.e., lower than min(node_id)
   frame[["depth"]] <- calculate_tree_depth_(
-    node_id = seq_len(nrow(frame)),
-    left_child = frame[["left daughter"]],
-    right_child = frame[["right daughter"]]
+    as.matrix(frame[, c("left daughter", "right daughter")])
   )
   return(frame)
 }
@@ -19,22 +16,29 @@ calculate_tree_depth_ranger <- function(frame){
     stop("The data frame has to contain columns called 'rightChild' and 'leftChild'!
          It should be a product of the function ranger::treeInfo().")
   }
+  # Child nodes are zero based, so we increase them by 1
   frame[["depth"]] <- calculate_tree_depth_(
-    node_id = frame[["nodeID"]],
-    left_child = frame[["leftChild"]],
-    right_child = frame[["rightChild"]]
+    as.matrix(frame[, c("leftChild", "rightChild")]) + 1
   )
   return(frame)
 }
 
 # Internal function used to determine the depth of each node
-calculate_tree_depth_ <- function(node_id, left_child, right_child) {
-  n <- length(node_id)
-  depth <- numeric(n)
-  for (i in 2:n) {
-    parent_node <- left_child %in% node_id[i] | right_child %in% node_id[i]
-    depth[i] <- depth[parent_node] + 1
+# Node indices are assumed to have values in 1:nrow(childs)
+calculate_tree_depth_ <- function(childs) {
+  n <- nrow(childs)
+  node_id <- seq_len(n)
+  depth <- rep(NA, times = n)
+  j <- depth[1L] <- 0
+  ix <- 1
+
+  # j loops over tree depth
+  while(anyNA(depth) || j >= n) {
+    ix <- c(childs[ix, ])
+    j <- j + 1
+    depth[ix] <- j
   }
+
   return(depth)
 }
 

--- a/R/min_depth_distribution.R
+++ b/R/min_depth_distribution.R
@@ -23,8 +23,8 @@ calculate_tree_depth_ranger <- function(frame){
   return(frame)
 }
 
-# Internal function used to determine the depth of each node
-# Node indices are assumed to have values in 1:nrow(childs)
+# Internal function used to determine the depth of each node.
+# The input is a with left and right child node indices in 1:nrow(childs).
 calculate_tree_depth_ <- function(childs) {
   n <- nrow(childs)
   depth <- rep(NA, times = n)
@@ -32,9 +32,9 @@ calculate_tree_depth_ <- function(childs) {
   ix <- 1L  # current nodes, initialized with root node index
 
   # j loops over tree depth
-  while(anyNA(depth) || j >= n) {
+  while(anyNA(depth) && j < n) {  # The second condition is never used
     ix <- as.integer(childs[ix, ])
-    ix <- ix[!is.na(ix) & ix >= 1L]  # leave nodes do not have childs
+    ix <- ix[!is.na(ix) & ix >= 1L]  # leaf nodes do not have childs
     j <- j + 1
     depth[ix] <- j
   }

--- a/R/min_depth_distribution.R
+++ b/R/min_depth_distribution.R
@@ -24,7 +24,7 @@ calculate_tree_depth_ranger <- function(frame){
 }
 
 # Internal function used to determine the depth of each node.
-# The input is a with left and right child node indices in 1:nrow(childs).
+# The input is a matrix with left and right child nodes in 1:nrow(childs).
 calculate_tree_depth_ <- function(childs) {
   n <- nrow(childs)
   depth <- rep(NA, times = n)


### PR DESCRIPTION
This PR brings an exponential speed-up in calculating the min depth distribution. The speed gain is especially strong for very deep trees, as with random forests fitted on larger data.

The trick is to loop over tree depth instead of looping over tree nodes.

As such, it solves #34 and adds to PR #35 which mainly (and unfortunately) brought a speed-up only for small trees.

```
library(randomForest)
library(randomForestExplainer)
library(ranger)
library(ggplot2)

set.seed(12)

# Random forest
fit <- randomForest(price~carat+color+cut+clarity, data = diamonds, ntree = 100)
system.time(  # 24s -> 0.6s
  out <- min_depth_distribution(fit)
)
head(out)
#   tree variable minimal_depth
# 1    1    carat             2
# 2    1  clarity             0
# 3    1    color             2
# 4    1      cut             3
# 5    2    carat             2
# 6    2  clarity             3


# Ranger (seems to grow much deeper trees)
fit2 <- ranger(
  price~carat+color+cut+clarity, data = diamonds,
  num.trees = 100,
  max.depth = 10, # without this, the original depth calculation won't stop
  seed = 1
)
system.time(  # 19s -> 0.1s
  out <- min_depth_distribution(fit2)
)
head(out)

#   tree variable minimal_depth
# 1    1    carat             1
# 2    1  clarity             0
# 3    1    color             2
# 4    1      cut             2
# 5    2    carat             2
```